### PR TITLE
Provide the connectionDefinitionBuilder in AbstractQueryRewriter through DI instead of by subclassing

### DIFF
--- a/doc/changes/changes_9.0.0.md
+++ b/doc/changes/changes_9.0.0.md
@@ -16,6 +16,7 @@ design and interface:
 ## Refactoring
 
 * #64: Refactored the `AbstractRemoteMetadataReader` and `TableMetadataReader` interface
+* #74: Provide the `connectionDefinitionBuilder` in `AbstractQueryRewriter` through DI instead of by subclassing.
 * #75: Restricted the amount of mapped tables in the remote schema to 1000.
 * #77: Refactored SQL generation for scalar functions.
 * #79: Added error builder to the project.

--- a/src/main/java/com/exasol/adapter/dialects/rewriting/AbstractQueryRewriter.java
+++ b/src/main/java/com/exasol/adapter/dialects/rewriting/AbstractQueryRewriter.java
@@ -7,7 +7,8 @@ import com.exasol.*;
 import com.exasol.adapter.AdapterException;
 import com.exasol.adapter.AdapterProperties;
 import com.exasol.adapter.dialects.*;
-import com.exasol.adapter.jdbc.*;
+import com.exasol.adapter.jdbc.ConnectionDefinitionBuilder;
+import com.exasol.adapter.jdbc.RemoteMetadataReader;
 import com.exasol.adapter.sql.SqlStatement;
 import com.exasol.errorreporting.ExaError;
 
@@ -23,24 +24,15 @@ public abstract class AbstractQueryRewriter implements QueryRewriter {
     /**
      * Create a new instance of a {@link AbstractQueryRewriter}.
      *
-     * @param dialect              dialect
-     * @param remoteMetadataReader remote metadata reader
+     * @param dialect                     dialect
+     * @param remoteMetadataReader        remote metadata reader
+     * @param connectionDefinitionBuilder builder for creating connection definitions
      */
-    protected AbstractQueryRewriter(final SqlDialect dialect, final RemoteMetadataReader remoteMetadataReader) {
+    protected AbstractQueryRewriter(final SqlDialect dialect, final RemoteMetadataReader remoteMetadataReader,
+            final ConnectionDefinitionBuilder connectionDefinitionBuilder) {
         this.dialect = dialect;
         this.remoteMetadataReader = remoteMetadataReader;
-        this.connectionDefinitionBuilder = createConnectionDefinitionBuilder();
-    }
-
-    /**
-     * Create the connection definition builder.
-     * <p>
-     * Override this method in case you need connection definitions that differ from the regular JDBC style.
-     *
-     * @return connection definition builder
-     */
-    protected ConnectionDefinitionBuilder createConnectionDefinitionBuilder() {
-        return new BaseConnectionDefinitionBuilder();
+        this.connectionDefinitionBuilder = connectionDefinitionBuilder;
     }
 
     @Override

--- a/src/main/java/com/exasol/adapter/dialects/rewriting/ImportFromJDBCQueryRewriter.java
+++ b/src/main/java/com/exasol/adapter/dialects/rewriting/ImportFromJDBCQueryRewriter.java
@@ -3,6 +3,7 @@ package com.exasol.adapter.dialects.rewriting;
 import java.sql.SQLException;
 
 import com.exasol.adapter.dialects.SqlDialect;
+import com.exasol.adapter.jdbc.BaseConnectionDefinitionBuilder;
 import com.exasol.adapter.jdbc.RemoteMetadataReader;
 
 /**
@@ -16,7 +17,7 @@ public class ImportFromJDBCQueryRewriter extends AbstractQueryRewriter {
      * @param remoteMetadataReader remote metadata reader
      */
     public ImportFromJDBCQueryRewriter(final SqlDialect dialect, final RemoteMetadataReader remoteMetadataReader) {
-        super(dialect, remoteMetadataReader);
+        super(dialect, remoteMetadataReader, new BaseConnectionDefinitionBuilder());
     }
 
     @Override

--- a/src/main/java/com/exasol/adapter/dialects/rewriting/ImportIntoQueryRewriter.java
+++ b/src/main/java/com/exasol/adapter/dialects/rewriting/ImportIntoQueryRewriter.java
@@ -22,7 +22,7 @@ public class ImportIntoQueryRewriter extends AbstractQueryRewriter {
      */
     public ImportIntoQueryRewriter(final SqlDialect dialect, final RemoteMetadataReader remoteMetadataReader,
             final ConnectionFactory connectionFactory) {
-        super(dialect, remoteMetadataReader);
+        super(dialect, remoteMetadataReader, new BaseConnectionDefinitionBuilder());
         this.connectionFactory = connectionFactory;
     }
 

--- a/src/test/java/com/exasol/adapter/dialects/rewriting/AbstractQueryRewriterTest.java
+++ b/src/test/java/com/exasol/adapter/dialects/rewriting/AbstractQueryRewriterTest.java
@@ -15,6 +15,7 @@ import com.exasol.ExaMetadata;
 import com.exasol.adapter.AdapterException;
 import com.exasol.adapter.AdapterProperties;
 import com.exasol.adapter.dialects.SqlDialect;
+import com.exasol.adapter.jdbc.BaseConnectionDefinitionBuilder;
 import com.exasol.adapter.jdbc.RemoteMetadataReader;
 
 class AbstractQueryRewriterTest {
@@ -37,7 +38,7 @@ class AbstractQueryRewriterTest {
          * @param remoteMetadataReader remote metadata reader
          */
         protected DummyQueryRewriter(final SqlDialect dialect, final RemoteMetadataReader remoteMetadataReader) {
-            super(dialect, remoteMetadataReader);
+            super(dialect, remoteMetadataReader, new BaseConnectionDefinitionBuilder());
         }
 
         @Override


### PR DESCRIPTION
Closes #74.