### PR TITLE
* #99: Moved here the double and exactnumeric literals formatting from `virtual-schema-common-java`

### DIFF
--- a/doc/changes/changelog.md
+++ b/doc/changes/changelog.md
@@ -1,5 +1,6 @@
 # Changes
 
+* [9.0.2](changes_9.0.2.md)
 * [9.0.1](changes_9.0.1.md)
 * [9.0.0](changes_9.0.0.md)
 * [8.0.0](changes_8.0.0.md)

--- a/doc/changes/changes_9.0.2.md
+++ b/doc/changes/changes_9.0.2.md
@@ -4,7 +4,7 @@ Code name:
 
 ## Bug Fixes
 
-* #99: Moved here the double and exactnumeric literals formatting from `virtual-schema-common-java`(https://github.com/exasol/virtual-schema-common-java)
+* #99: Moved to this repository the double and exactnumeric literals formatting from `virtual-schema-common-java`(https://github.com/exasol/virtual-schema-common-java)
 
 ## Dependency Updates
 

--- a/doc/changes/changes_9.0.2.md
+++ b/doc/changes/changes_9.0.2.md
@@ -1,0 +1,13 @@
+# Virtual Schema Common JDBC 9.0.2, released 2021-02-??
+
+Code name:
+
+## Bug Fixes
+
+* #99: Moved here the double and exactnumeric literals formatting from `virtual-schema-common-java`(https://github.com/exasol/virtual-schema-common-java)
+
+## Dependency Updates
+
+### Test Dependencies
+
+* Updated `com.exasol:virtual-schema-common-java:15.0.0` to `15.0.1`

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.exasol</groupId>
     <artifactId>virtual-schema-common-jdbc</artifactId>
-    <version>9.0.1</version>
+    <version>9.0.2</version>
     <name>Virtual Schema Common JDBC</name>
     <description>Common module for JDBC-based data access from Virtual Schemas.</description>
     <url>https://github.com/exasol/virtual-schema-common-jdbc</url>

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>com.exasol</groupId>
             <artifactId>virtual-schema-common-java</artifactId>
-            <version>15.0.0</version>
+            <version>15.0.1</version>
         </dependency>
         <dependency>
             <groupId>javax.xml.bind</groupId>

--- a/src/main/java/com/exasol/adapter/dialects/AbstractSqlDialect.java
+++ b/src/main/java/com/exasol/adapter/dialects/AbstractSqlDialect.java
@@ -179,8 +179,7 @@ public abstract class AbstractSqlDialect implements SqlDialect {
 
     protected String createUnsupportedElementMessage(final String unsupportedElement, final String property) {
         return ExaError.messageBuilder("E-VS-COM-JDBC-13")
-                .message("The dialect {{dialectName}} does not support {{unsupportedElement}} property.")
-                .parameter("dialectName", this.properties.getSqlDialect())
+                .message("This dialect does not support {{unsupportedElement}} property.")
                 .parameter("unsupportedElement", unsupportedElement)
                 .mitigation(" Please, do not set the {{property}} property.") //
                 .parameter("property", property).toString();

--- a/src/main/java/com/exasol/adapter/dialects/rewriting/SqlGenerationVisitor.java
+++ b/src/main/java/com/exasol/adapter/dialects/rewriting/SqlGenerationVisitor.java
@@ -1,5 +1,7 @@
 package com.exasol.adapter.dialects.rewriting;
 
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
 import java.util.*;
 
 import com.exasol.adapter.AdapterException;
@@ -441,14 +443,27 @@ public class SqlGenerationVisitor implements SqlNodeVisitor<String>, SqlGenerato
         return "DATE " + getDialect().getStringLiteral(literal.getValue());
     }
 
+    /**
+     * Get a value of the double converted to an E-notation format.
+     * <p>
+     * For example: 1.234 becomes 1.234E0
+     * </p>
+     */
     @Override
     public String visit(final SqlLiteralDouble literal) {
-        return literal.getValue();
+        final NumberFormat numFormat = new DecimalFormat("0.################E0");
+        return numFormat.format(literal.getValue());
     }
 
+    /**
+     * Formats a value of the exactnumeric as a plain string without E notation.
+     * <p>
+     * For example: 1E-35 becomes 0.00000000000000000000000000000000001
+     * </p>
+     */
     @Override
     public String visit(final SqlLiteralExactnumeric literal) {
-        return literal.getValue();
+        return literal.getValue().toPlainString();
     }
 
     @Override

--- a/src/test/java/com/exasol/adapter/dialects/SqlGenerationVisitorTest.java
+++ b/src/test/java/com/exasol/adapter/dialects/SqlGenerationVisitorTest.java
@@ -14,6 +14,8 @@ import java.util.*;
 
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 
 import com.exasol.adapter.AdapterException;
 import com.exasol.adapter.AdapterProperties;
@@ -242,16 +244,32 @@ class SqlGenerationVisitorTest {
         assertThat(sqlGenerationVisitor.visit(sqlLiteralDate), equalTo("DATE '2015-12-01'"));
     }
 
-    @Test
-    void testVisitSqlLiteralDouble() {
-        final SqlLiteralDouble sqlLiteralDouble = new SqlLiteralDouble(20.3);
-        assertThat(sqlGenerationVisitor.visit(sqlLiteralDouble), equalTo("2.03E1"));
+    @ParameterizedTest
+    @CsvSource({ "1.0, 1E0", //
+            "1.234, 1.234E0", //
+            "345600000000, 3.456E11", //
+            "0.0000000000000000009236, 9.236E-19", //
+            "0.00098, 9.8E-4", //
+            "1.2345000000000000e+02, 1.2345E2" //
+    })
+    void testVisitSqlLiteralDouble(final double input, final String expected) {
+        final SqlLiteralDouble sqlLiteralDouble = new SqlLiteralDouble(input);
+        assertThat(sqlGenerationVisitor.visit(sqlLiteralDouble), equalTo(expected));
     }
 
-    @Test
-    void testVisitSqlLiteralExactnumeric() {
-        final SqlLiteralExactnumeric sqlLiteralExactnumeric = new SqlLiteralExactnumeric(BigDecimal.TEN);
-        assertThat(sqlGenerationVisitor.visit(sqlLiteralExactnumeric), equalTo("10"));
+    @ParameterizedTest
+    @CsvSource({ "1E-35, 0.00000000000000000000000000000000001", //
+            "1E35, 100000000000000000000000000000000000", //
+            "12345, 12345", //
+            "3.456e11, 345600000000", //
+            "9.8e-4, 0.00098", //
+            "9.236E-19, 0.0000000000000000009236", //
+            "123.45, 123.45", //
+            "12345, 12345" //
+    })
+    void testVisitSqlLiteralExactnumeric(final BigDecimal input, final String expected) {
+        final SqlLiteralExactnumeric sqlLiteralExactnumeric = new SqlLiteralExactnumeric(input);
+        assertThat(sqlGenerationVisitor.visit(sqlLiteralExactnumeric), equalTo(expected));
     }
 
     @Test


### PR DESCRIPTION
Closes #99 