### PR TITLE
#178: Fixed `SqlGenerationHelper.selectListRequiresCasts()` to stop scanning columns after the first cast requirement was found

### DIFF
--- a/doc/changes/changes_14.0.3.md
+++ b/doc/changes/changes_14.0.3.md
@@ -16,6 +16,7 @@ The release also makes interfaces `SqlDialectFactory`, `SqlDialect` and `Connect
 * #182: Fixed dependency on mutating `subtractCapabilities()` method
 * #163: Fixed `JDBCAdapter.pushdown()` clearing the connection cache after successful requests.
 * #173: Fixed deserialization of column adapter notes when `typeName` is absent.
+* #177: Fixed JDBC metadata mapping for invalid and oversized character types.
 
 ## Dependency Updates
 

--- a/doc/changes/changes_14.0.3.md
+++ b/doc/changes/changes_14.0.3.md
@@ -12,6 +12,7 @@ The release also makes interfaces `SqlDialectFactory`, `SqlDialect` and `Connect
 
 ## Bugfixes
 
+* #178: Fixed `SqlGenerationHelper.selectListRequiresCasts()` to stop scanning columns after the first cast requirement was found.
 * #174: Fix JDBCAdapter connection cleanup and lazy connection factory race
 * #182: Fixed dependency on mutating `subtractCapabilities()` method
 * #163: Fixed `JDBCAdapter.pushdown()` clearing the connection cache after successful requests.

--- a/error_code_config.yml
+++ b/error_code_config.yml
@@ -2,4 +2,4 @@ error-tags:
   VSCJDBC:
     packages:
       - com.exasol
-    highest-index: 51
+    highest-index: 55

--- a/src/main/java/com/exasol/adapter/dialects/rewriting/SqlGenerationHelper.java
+++ b/src/main/java/com/exasol/adapter/dialects/rewriting/SqlGenerationHelper.java
@@ -48,7 +48,6 @@ public final class SqlGenerationHelper {
      */
     public static boolean selectListRequiresCasts(final SqlSelectList selectList,
             final Predicate<SqlNode> nodeRequiresCast) {
-        boolean requiresCasts = false;
         final SqlStatementSelect select = (SqlStatementSelect) selectList.getParent();
         final int columnId = 0;
         final List<TableMetadata> tableMetadata = new ArrayList<>();
@@ -56,11 +55,11 @@ public final class SqlGenerationHelper {
         for (final TableMetadata tableMeta : tableMetadata) {
             for (final ColumnMetadata columnMeta : tableMeta.getColumns()) {
                 if (nodeRequiresCast.test(new SqlColumn(columnId, columnMeta))) {
-                    requiresCasts = true;
+                    return true;
                 }
             }
         }
-        return requiresCasts;
+        return false;
     }
 
     /**

--- a/src/main/java/com/exasol/adapter/jdbc/BaseColumnMetadataReader.java
+++ b/src/main/java/com/exasol/adapter/jdbc/BaseColumnMetadataReader.java
@@ -62,7 +62,7 @@ public class BaseColumnMetadataReader extends AbstractMetadataReader implements 
      * @param identifierConverter converter between source and Exasol identifiers
      */
     public BaseColumnMetadataReader(final Connection connection, final AdapterProperties properties,
-                final ExaMetadata exaMetadata, final IdentifierConverter identifierConverter) {
+            final ExaMetadata exaMetadata, final IdentifierConverter identifierConverter) {
         super(connection, properties, exaMetadata);
         this.identifierConverter = identifierConverter;
         this.supportsTimestampsWithNanoPrecision = ExasolVersion.parse(exaMetadata).atLeast(8, 32);
@@ -70,6 +70,7 @@ public class BaseColumnMetadataReader extends AbstractMetadataReader implements 
 
     /**
      * Whether the Exasol database supports timestamp with precision up to nanoseconds.
+     * 
      * @return true if Exasol database supports timestamps with nanoseconds precision false otherwise.
      */
     protected boolean supportsTimestampsWithNanoPrecision() {
@@ -315,42 +316,42 @@ public class BaseColumnMetadataReader extends AbstractMetadataReader implements 
     @Override
     public DataType mapJdbcType(final JDBCTypeDescription jdbcTypeDescription) {
         switch (jdbcTypeDescription.getJdbcType()) {
-        case Types.TINYINT:
-        case Types.SMALLINT:
-            return convertSmallInteger(jdbcTypeDescription.getPrecisionOrSize());
-        case Types.INTEGER:
-            return convertInteger(jdbcTypeDescription.getPrecisionOrSize());
-        case Types.BIGINT:
-            return convertBigInteger(jdbcTypeDescription.getPrecisionOrSize());
-        case Types.DECIMAL:
-            return convertDecimal(jdbcTypeDescription.getPrecisionOrSize(), jdbcTypeDescription.getDecimalScale());
-        case Types.REAL:
-        case Types.FLOAT:
-        case Types.DOUBLE:
-            return DataType.createDouble();
-        case Types.VARCHAR:
-        case Types.NVARCHAR:
-        case Types.LONGVARCHAR:
-        case Types.LONGNVARCHAR:
-            return convertVarChar(jdbcTypeDescription.getPrecisionOrSize());
-        case Types.CHAR:
-        case Types.NCHAR:
-            return convertChar(jdbcTypeDescription.getPrecisionOrSize());
-        case Types.DATE:
-            return DataType.createDate();
-        case Types.TIMESTAMP:
-            return convertTimestamp(jdbcTypeDescription.getDecimalScale());
-        case Types.BIT:
-        case Types.BOOLEAN:
-            return DataType.createBool();
-        case Types.TIME:
-        case Types.TIMESTAMP_WITH_TIMEZONE:
-            return DataType.createVarChar(100, UTF8);
-        case Types.NUMERIC:
-            return fallBackToMaximumSizeVarChar();
-        default:
-            LOGGER.finer("Found unsupported type: " + jdbcTypeDescription.getJdbcType());
-            return DataType.createUnsupported();
+            case Types.TINYINT:
+            case Types.SMALLINT:
+                return convertSmallInteger(jdbcTypeDescription.getPrecisionOrSize());
+            case Types.INTEGER:
+                return convertInteger(jdbcTypeDescription.getPrecisionOrSize());
+            case Types.BIGINT:
+                return convertBigInteger(jdbcTypeDescription.getPrecisionOrSize());
+            case Types.DECIMAL:
+                return convertDecimal(jdbcTypeDescription.getPrecisionOrSize(), jdbcTypeDescription.getDecimalScale());
+            case Types.REAL:
+            case Types.FLOAT:
+            case Types.DOUBLE:
+                return DataType.createDouble();
+            case Types.VARCHAR:
+            case Types.NVARCHAR:
+            case Types.LONGVARCHAR:
+            case Types.LONGNVARCHAR:
+                return convertVarChar(jdbcTypeDescription.getPrecisionOrSize());
+            case Types.CHAR:
+            case Types.NCHAR:
+                return convertChar(jdbcTypeDescription.getPrecisionOrSize());
+            case Types.DATE:
+                return DataType.createDate();
+            case Types.TIMESTAMP:
+                return convertTimestamp(jdbcTypeDescription.getDecimalScale());
+            case Types.BIT:
+            case Types.BOOLEAN:
+                return DataType.createBool();
+            case Types.TIME:
+            case Types.TIMESTAMP_WITH_TIMEZONE:
+                return DataType.createVarChar(100, UTF8);
+            case Types.NUMERIC:
+                return fallBackToMaximumSizeVarChar();
+            default:
+                LOGGER.finer("Found unsupported type: " + jdbcTypeDescription.getJdbcType());
+                return DataType.createUnsupported();
         }
     }
 
@@ -398,24 +399,40 @@ public class BaseColumnMetadataReader extends AbstractMetadataReader implements 
 
     private static DataType convertVarChar(final int size) {
         final DataType.ExaCharset charset = UTF8;
-        if (size <= DataType.MAX_EXASOL_VARCHAR_SIZE) {
-            final int precision = size == 0 ? DataType.MAX_EXASOL_VARCHAR_SIZE : size;
-            return DataType.createVarChar(precision, charset);
+        if (size <= 0) {
+            return DataType.createVarChar(DataType.MAX_EXASOL_VARCHAR_SIZE, charset);
+        } else if (size <= DataType.MAX_EXASOL_VARCHAR_SIZE) {
+            return DataType.createVarChar(size, charset);
         } else {
+            LOGGER.warning(() -> ExaError.messageBuilder("W-VSCJDBC-53")
+                    .message("VARCHAR size {{size}} exceeds the maximum Exasol VARCHAR size {{maxSize}}."
+                            + " Mapping to maximum-size VARCHAR instead.",
+                            size, DataType.MAX_EXASOL_VARCHAR_SIZE)
+                    .toString());
             return DataType.createVarChar(DataType.MAX_EXASOL_VARCHAR_SIZE, charset);
         }
     }
 
     private static DataType convertChar(final int size) {
         final DataType.ExaCharset charset = UTF8;
-        if (size <= DataType.MAX_EXASOL_CHAR_SIZE) {
+        if (size <= 0) {
+            return DataType.createVarChar(DataType.MAX_EXASOL_VARCHAR_SIZE, charset);
+        } else if (size <= DataType.MAX_EXASOL_CHAR_SIZE) {
             return DataType.createChar(size, charset);
+        } else if (size <= DataType.MAX_EXASOL_VARCHAR_SIZE) {
+            LOGGER.warning(() -> ExaError.messageBuilder("W-VSCJDBC-54")
+                    .message("CHAR size {{size}} exceeds the maximum Exasol CHAR size {{maxCharSize}}."
+                            + " Mapping to VARCHAR({{size}}) instead.",
+                            size, DataType.MAX_EXASOL_CHAR_SIZE)
+                    .toString());
+            return DataType.createVarChar(size, charset);
         } else {
-            if (size <= DataType.MAX_EXASOL_VARCHAR_SIZE) {
-                return DataType.createVarChar(size, charset);
-            } else {
-                return DataType.createVarChar(DataType.MAX_EXASOL_VARCHAR_SIZE, charset);
-            }
+            LOGGER.warning(() -> ExaError.messageBuilder("W-VSCJDBC-55")
+                    .message("CHAR size {{size}} exceeds the maximum Exasol VARCHAR size {{maxSize}}."
+                            + " Mapping to maximum-size VARCHAR instead.",
+                            size, DataType.MAX_EXASOL_VARCHAR_SIZE)
+                    .toString());
+            return DataType.createVarChar(DataType.MAX_EXASOL_VARCHAR_SIZE, charset);
         }
     }
 

--- a/src/test/java/com/exasol/adapter/dialects/rewriting/SqlGenerationHelperTest.java
+++ b/src/test/java/com/exasol/adapter/dialects/rewriting/SqlGenerationHelperTest.java
@@ -1,0 +1,75 @@
+package com.exasol.adapter.dialects.rewriting;
+
+import static com.exasol.adapter.dialects.rewriting.SqlGenerationHelper.selectListRequiresCasts;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Predicate;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.exasol.adapter.metadata.*;
+import com.exasol.adapter.sql.*;
+
+@ExtendWith(MockitoExtension.class)
+class SqlGenerationHelperTest {
+    @Mock
+    Predicate<SqlNode> predicate;
+    @Mock
+    SqlSelectList selectList;
+    @Mock
+    SqlStatementSelect select;
+
+    @BeforeEach
+    void setup() {
+        when(selectList.getParent()).thenReturn(select);
+        when(select.getFromClause()).thenReturn(new SqlTable("TEST",
+                new TableMetadata("TEST", "", List.of(
+                        createColumnMetadata("FIRST"),
+                        createColumnMetadata("SECOND")), "")));
+    }
+
+    @Test
+    void testSelectListRequiresCastsShortCircuitsAfterFirstMatch() {
+        final AtomicInteger invocations = new AtomicInteger();
+        when(predicate.test(any())).thenAnswer(invocation -> {
+            final SqlColumn column = invocation.getArgument(0);
+            if (invocations.getAndIncrement() == 0) {
+                assertThat(column.getName(), equalTo("FIRST"));
+                return true;
+            }
+            throw new AssertionError("selectListRequiresCasts() must stop after the first matching column");
+        });
+
+        final boolean actual = selectListRequiresCasts(selectList, predicate);
+
+        assertAll(
+                () -> assertThat(actual, is(true)),
+                () -> verify(predicate, times(1)).test(any()));
+    }
+
+    @Test
+    void testSelectListRequiresCastsChecksAllColumnsWhenNoneMatch() {
+        when(predicate.test(any())).thenReturn(false);
+
+        final boolean actual = selectListRequiresCasts(selectList, predicate);
+
+        assertAll(
+                () -> assertThat(actual, is(false)),
+                () -> verify(predicate, times(2)).test(any()));
+    }
+
+    private ColumnMetadata createColumnMetadata(final String columnName) {
+        return ColumnMetadata.builder().name(columnName).type(DataType.createBool()).build();
+    }
+}

--- a/src/test/java/com/exasol/adapter/jdbc/BaseColumnMetadataReaderTest.java
+++ b/src/test/java/com/exasol/adapter/jdbc/BaseColumnMetadataReaderTest.java
@@ -5,44 +5,57 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.junit.jupiter.api.Assertions.assertAll;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
 import java.sql.*;
 import java.util.List;
 import java.util.Map;
+import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
-import com.exasol.ExaMetadata;
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Test;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+import com.exasol.ExaMetadata;
 import com.exasol.adapter.AdapterProperties;
 import com.exasol.adapter.dialects.BaseIdentifierConverter;
 import com.exasol.adapter.dialects.IdentifierCaseHandling;
 import com.exasol.adapter.metadata.ColumnMetadata;
 import com.exasol.adapter.metadata.DataType;
 import com.exasol.adapter.metadata.DataType.ExaDataType;
-import org.mockito.Mock;
-import org.mockito.junit.jupiter.MockitoExtension;
+import com.exasol.logging.CapturingLogHandler;
 
 @ExtendWith(MockitoExtension.class)
 class BaseColumnMetadataReaderTest {
+    private static final DataType MAX_VARCHAR_UTF8 = DataType.createVarChar(DataType.MAX_EXASOL_VARCHAR_SIZE,
+            UTF8);
 
     @Mock
     private ExaMetadata exaMetadataMock;
 
+    private final CapturingLogHandler capturingLogHandler = new CapturingLogHandler();
     private BaseColumnMetadataReader reader;
 
     @BeforeEach
     void beforeEach() {
         when(this.exaMetadataMock.getDatabaseVersion()).thenReturn("8.34.0");
+        Logger.getLogger("com.exasol").addHandler(this.capturingLogHandler);
+        this.capturingLogHandler.reset();
         this.reader = new BaseColumnMetadataReader(null, AdapterProperties.emptyProperties(), exaMetadataMock,
                 new BaseIdentifierConverter(IdentifierCaseHandling.INTERPRET_AS_UPPER,
                         IdentifierCaseHandling.INTERPRET_CASE_SENSITIVE));
+    }
+
+    @AfterEach
+    void afterEach() {
+        Logger.getLogger("com.exasol").removeHandler(this.capturingLogHandler);
     }
 
     @ValueSource(ints = { Types.BINARY, Types.CLOB, Types.OTHER, Types.BLOB, Types.NCLOB, Types.LONGVARBINARY,
@@ -57,7 +70,7 @@ class BaseColumnMetadataReaderTest {
     @Test
     void testMappingNumericToMaxSizeVarchar() {
         final JDBCTypeDescription jdbcTypeDescription = new JDBCTypeDescription(Types.NUMERIC, 0, 0, 0, null);
-        assertThat(this.reader.mapJdbcType(jdbcTypeDescription), equalTo(DataType.createMaximumSizeVarChar(UTF8)));
+        assertThat(this.reader.mapJdbcType(jdbcTypeDescription), equalTo(MAX_VARCHAR_UTF8));
     }
 
     @ValueSource(ints = { Types.TIME, Types.TIMESTAMP_WITH_TIMEZONE })
@@ -65,6 +78,20 @@ class BaseColumnMetadataReaderTest {
     void testMappingDateTimeToVarchar(final int jdbcType) {
         final JDBCTypeDescription jdbcTypeDescription = new JDBCTypeDescription(jdbcType, 0, 0, 0, null);
         assertThat(this.reader.mapJdbcType(jdbcTypeDescription), equalTo(DataType.createVarChar(100, UTF8)));
+    }
+
+    @ValueSource(ints = { Types.CHAR, Types.NCHAR })
+    @ParameterizedTest
+    void testParseCharZeroMapsToMaximumSizeVarchar(final int typeId) {
+        final JDBCTypeDescription jdbcTypeDescription = new JDBCTypeDescription(typeId, 0, 0, 0, "");
+        assertThat(this.reader.mapJdbcType(jdbcTypeDescription), equalTo(MAX_VARCHAR_UTF8));
+    }
+
+    @ValueSource(ints = { Types.CHAR, Types.NCHAR })
+    @ParameterizedTest
+    void testParseCharNegativeMapsToMaximumSizeVarchar(final int typeId) {
+        final JDBCTypeDescription jdbcTypeDescription = new JDBCTypeDescription(typeId, 1, -1, 1, "");
+        assertThat(this.reader.mapJdbcType(jdbcTypeDescription), equalTo(MAX_VARCHAR_UTF8));
     }
 
     @Test
@@ -99,6 +126,26 @@ class BaseColumnMetadataReaderTest {
                 equalTo(DataType.createDecimal(DataType.MAX_EXASOL_DECIMAL_PRECISION, 10)));
     }
 
+    @ValueSource(ints = { Types.CHAR, Types.NCHAR })
+    @ParameterizedTest
+    void testParseCharExceedsMaxCharSizeLogsWarningAndMapsToVarchar(final int typeId) {
+        final int size = DataType.MAX_EXASOL_CHAR_SIZE + 1;
+        final JDBCTypeDescription jdbcTypeDescription = new JDBCTypeDescription(typeId, 0, size, 0, "");
+        assertAll(() -> assertThat(this.reader.mapJdbcType(jdbcTypeDescription), equalTo(DataType.createVarChar(size, UTF8))),
+                () -> assertThat(this.capturingLogHandler.getCapturedData(), containsString(
+                        "W-VSCJDBC-54: CHAR size 2001 exceeds the maximum Exasol CHAR size 2000. Mapping to VARCHAR(2001) instead")));
+    }
+
+    @ValueSource(ints = { Types.CHAR, Types.NCHAR })
+    @ParameterizedTest
+    void testParseCharExceedsMaxVarCharSizeLogsWarningAndMapsToMaximumSizeVarchar(final int typeId) {
+        final int size = DataType.MAX_EXASOL_VARCHAR_SIZE + 1;
+        final JDBCTypeDescription jdbcTypeDescription = new JDBCTypeDescription(typeId, 0, size, 0, "");
+        assertAll(() -> assertThat(this.reader.mapJdbcType(jdbcTypeDescription), equalTo(MAX_VARCHAR_UTF8)),
+                () -> assertThat(this.capturingLogHandler.getCapturedData(), containsString(
+                        "W-VSCJDBC-55: CHAR size 2000001 exceeds the maximum Exasol VARCHAR size 2000000. Mapping to maximum-size VARCHAR instead")));
+    }
+
     @ValueSource(ints = { 256, 65536, 2000000 }) // 2 pow 8, 2 pow 16, max
     @ParameterizedTest
     void mapLongVarchar(final int size) {
@@ -106,20 +153,38 @@ class BaseColumnMetadataReaderTest {
         assertThat(this.reader.mapJdbcType(typeDescription), equalTo(DataType.createVarChar(size, UTF8)));
     }
 
+    @ValueSource(ints = { Types.VARCHAR, Types.NVARCHAR, Types.LONGVARCHAR, Types.LONGNVARCHAR })
+    @ParameterizedTest
+    void testParseVarCharZeroMapsToMaximumSizeVarchar(final int typeId) {
+        final JDBCTypeDescription jdbcTypeDescription = new JDBCTypeDescription(typeId, 0, 0, 0, "");
+        assertThat(this.reader.mapJdbcType(jdbcTypeDescription), equalTo(MAX_VARCHAR_UTF8));
+    }
+
+    @ValueSource(ints = { Types.VARCHAR, Types.NVARCHAR, Types.LONGVARCHAR, Types.LONGNVARCHAR })
+    @ParameterizedTest
+    void testParseVarCharExceedsMaxSizeLogsWarningAndMapsToMaximumSizeVarchar(final int typeId) {
+        final int size = DataType.MAX_EXASOL_VARCHAR_SIZE + 1;
+        final JDBCTypeDescription jdbcTypeDescription = new JDBCTypeDescription(typeId, 0, size, 0, "");
+        assertAll(() -> assertThat(this.reader.mapJdbcType(jdbcTypeDescription), equalTo(MAX_VARCHAR_UTF8)),
+                () -> assertThat(this.capturingLogHandler.getCapturedData(), containsString(
+                        "W-VSCJDBC-53: VARCHAR size 2000001 exceeds the maximum Exasol VARCHAR size 2000000. Mapping to maximum-size VARCHAR instead")));
+    }
+
     @ValueSource(ints = { 2000001, 16777216 }) // max + 1, 2 pow 24
     @ParameterizedTest
-    void mapLongVarcharToUnsupportedIfTooLarge(final int size) {
+    void mapLongVarcharToMaximumSizeVarcharIfTooLarge(final int size) {
         final JDBCTypeDescription typeDescription = new JDBCTypeDescription(Types.LONGVARCHAR, 0, size, 0, "VARCHAR");
-        assertThat(this.reader.mapJdbcType(typeDescription), equalTo(DataType.createMaximumSizeVarChar(UTF8)));
+        assertThat(this.reader.mapJdbcType(typeDescription), equalTo(MAX_VARCHAR_UTF8));
     }
 
     @Test
     void testGetNumberTypeFromProperty() {
-        final BaseColumnMetadataReader reader = new BaseColumnMetadataReader(null,
+        final BaseColumnMetadataReader metadataReader = new BaseColumnMetadataReader(null,
                 new AdapterProperties(Map.of("SOME_PROPERTY", "abc")), exaMetadataMock, new BaseIdentifierConverter(
                         IdentifierCaseHandling.INTERPRET_AS_UPPER, IdentifierCaseHandling.INTERPRET_CASE_SENSITIVE));
         final IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
-                () -> reader.getNumberTypeFromProperty("SOME_PROPERTY"));
-        assertThat(exception.getMessage(), containsString("E-VSCJDBC-2"));
+                () -> metadataReader.getNumberTypeFromProperty("SOME_PROPERTY"));
+        assertThat(exception.getMessage(), Matchers.startsWith(
+                "E-VSCJDBC-2: Unable to parse adapter property SOME_PROPERTY value 'abc' into a number precision and scale."));
     }
 }


### PR DESCRIPTION
Closes #178